### PR TITLE
raise TimeoutError on connection timeout

### DIFF
--- a/client.py
+++ b/client.py
@@ -48,7 +48,7 @@ class SampClient(object):
             response = self.socket.recv(buffersize)
             return response[11:] if strip_header else response
         except socket.timeout as e:
-            pass
+            raise TimeoutError("Connection timeout") from e
         except socket.error as e:
             raise ConnectionError(e)
 


### PR DESCRIPTION
@enginestein, Hello!
I am getting error `'NoneType' object is not subscriptable`, when trying get server info

Code from my application:
```python
with SampClient(server.ip, server.port) as client:
    info_from_server = client.get_server_info()
```

```python
Traceback (most recent call last):

> File "/app/app/utils.py", line 34, in get_server_info
    info_from_server = client.get_server_info()
                       |      -> <function SampClient.get_server_info at 0x7f8cef126840>
                       -> <samp_py.client.SampClient object at 0x7f8cef3009b0>

  File "/usr/local/lib/python3.12/site-packages/samp_py/client.py", line 59, in get_server_info
    hostname = decode_string(response, 5, 4)
               |             -> None
               -> <function decode_string at 0x7f8cef1262a0>
  File "/usr/local/lib/python3.12/site-packages/samp_py/utils.py", line 56, in decode_string
    length = decode_int(string[len_pos:len_end])
             |          |      |       -> 9
             |          |      -> 5
             |          -> None
             -> <function decode_int at 0x7f8cef126200>

TypeError: 'NoneType' object is not subscriptable
```

Reading through the code, I found that `client.SampClient.receive` method [return None on timeout error](https://github.com/enginestein/SAMP.py/blob/9c71f5a748c3d17255a31bd12446a1192840cea2/samp_py/client.py#L51).  

So `send_request` method that call `receive` method [return None too](https://github.com/enginestein/SAMP.py/blob/9c71f5a748c3d17255a31bd12446a1192840cea2/samp_py/client.py#L44).

And this `None` goes into the `utils.decode_string` function, where the error occurs.

I suggest raising an builtin `TimeoutError` on connection timeout instead of return `None`

P.S: Any suggestions and corrections would be welcome